### PR TITLE
Add GPIO interface for RFNoC blocks

### DIFF
--- a/fpga/usrp3/top/x300/bus_int.v
+++ b/fpga/usrp3/top/x300/bus_int.v
@@ -49,8 +49,14 @@ module bus_int #(
     // Front-panel GPIO source
     output [23:0] fp_gpio_src,
     // Daughterboard GPIO
-    input [31:0] gpio_db0,
-    input [31:0] gpio_db1,
+    input  [31:0] db0_gpio_in,
+    output [31:0] db0_gpio_ctr,
+    output [31:0] db0_gpio_ddr,
+    output [31:0] db0_gpio_out,
+    input  [31:0] db1_gpio_in,
+    output [31:0] db1_gpio_ctr,
+    output [31:0] db1_gpio_ddr,
+    output [31:0] db1_gpio_out,
     // Clock control and status
     input [7:0] clock_status, output [7:0] clock_control, output [31:0] ref_freq, output ref_freq_changed,
     // SFP+ 0 data stream
@@ -820,10 +826,22 @@ module bus_int #(
     .radio_tx_data_radio1           (radio_tx_data[127:64] ),
     .radio_tx_running_radio1        (radio_tx_running[3:2] ),
     // Daughterboard GPIO
-    .gpio_db0_rx                    (gpio_db0[0+:16]),
-    .gpio_db0_tx                    (gpio_db0[16+:16]),
-    .gpio_db1_rx                    (gpio_db1[0+:16]),
-    .gpio_db1_tx                    (gpio_db1[16+:16]),
+    .gpio_db0_rx_in                 (db0_gpio_in[0+:16]),
+    .gpio_db0_rx_ctr                (db0_gpio_ctr[0+:16]),
+    .gpio_db0_rx_ddr                (db0_gpio_ddr[0+:16]),
+    .gpio_db0_rx_out                (db0_gpio_out[0+:16]),
+    .gpio_db0_tx_in                 (db0_gpio_in[16+:16]),
+    .gpio_db0_tx_ctr                (db0_gpio_ctr[16+:16]),
+    .gpio_db0_tx_ddr                (db0_gpio_ddr[16+:16]),
+    .gpio_db0_tx_out                (db0_gpio_out[16+:16]),
+    .gpio_db1_rx_in                 (db1_gpio_in[0+:16]),
+    .gpio_db1_rx_ctr                (db1_gpio_ctr[0+:16]),
+    .gpio_db1_rx_ddr                (db1_gpio_ddr[0+:16]),
+    .gpio_db1_rx_out                (db1_gpio_out[0+:16]),
+    .gpio_db1_tx_in                 (db1_gpio_in[16+:16]),
+    .gpio_db1_tx_ctr                (db1_gpio_ctr[16+:16]),
+    .gpio_db1_tx_ddr                (db1_gpio_ddr[16+:16]),
+    .gpio_db1_tx_out                (db1_gpio_out[16+:16]),
     // DRAM interface
     .axi_rst                 (ddr3_axi_rst),
     // Slave Interface Write Address Ports

--- a/fpga/usrp3/top/x300/bus_int.v
+++ b/fpga/usrp3/top/x300/bus_int.v
@@ -48,6 +48,9 @@ module bus_int #(
     input SFPP1_ModAbs, input SFPP1_TxFault, input SFPP1_RxLOS, inout SFPP1_RS0, inout SFPP1_RS1,
     // Front-panel GPIO source
     output [23:0] fp_gpio_src,
+    // Daughterboard GPIO
+    input [31:0] gpio_db0,
+    input [31:0] gpio_db1,
     // Clock control and status
     input [7:0] clock_status, output [7:0] clock_control, output [31:0] ref_freq, output ref_freq_changed,
     // SFP+ 0 data stream
@@ -816,6 +819,11 @@ module bus_int #(
     .radio_tx_stb_radio1            (radio_tx_stb[3:2]     ),
     .radio_tx_data_radio1           (radio_tx_data[127:64] ),
     .radio_tx_running_radio1        (radio_tx_running[3:2] ),
+    // Daughterboard GPIO
+    .gpio_db0_rx                    (gpio_db0[0+:16]),
+    .gpio_db0_tx                    (gpio_db0[16+:16]),
+    .gpio_db1_rx                    (gpio_db1[0+:16]),
+    .gpio_db1_tx                    (gpio_db1[16+:16]),
     // DRAM interface
     .axi_rst                 (ddr3_axi_rst),
     // Slave Interface Write Address Ports

--- a/fpga/usrp3/top/x300/x300_core.v
+++ b/fpga/usrp3/top/x300/x300_core.v
@@ -317,6 +317,9 @@ module x300_core #(
       .SFPP1_RS0(SFPP1_RS0), .SFPP1_RS1(SFPP1_RS1),
       // Front-panel GPIO source
       .fp_gpio_src(sr_fp_gpio_src),
+      // Daughterboard GPIO (as input)
+      .gpio_db0(db0_gpio_in),
+      .gpio_db1(db1_gpio_in),
       //clocky locky misc
       .clock_status({misc_clock_status, pps_detect, LMK_Holdover, LMK_Lock, LMK_Status}),
       .clock_control({1'b0, clock_misc_opt[1:0], pps_out_enb, pps_select[1:0], clock_ref_sel[1:0]}),

--- a/host/include/uhd/rfnoc/core/io_signatures.yml
+++ b/host/include/uhd/rfnoc/core/io_signatures.yml
@@ -61,9 +61,13 @@ radio:
 db_gpio:
   type: broadcaster-listener
   ports:
-  - name: db_gpio_rx
+  - name: gpio_ctr
     width: 16
-  - name: db_gpio_tx
+  - name: gpio_ddr
+    width: 16
+  - name: gpio_in
+    width: 16
+  - name: gpio_out
     width: 16
 
 # AXI4 memory-mapped interface (up to 8 x 512-bit data and 48-bit address)

--- a/host/include/uhd/rfnoc/core/io_signatures.yml
+++ b/host/include/uhd/rfnoc/core/io_signatures.yml
@@ -57,6 +57,15 @@ radio:
     type: to-master
     width: 32
 
+# Daughterboard GPIO interface
+db_gpio:
+  type: broadcaster-listener
+  ports:
+  - name: db_gpio_rx
+    width: 16
+  - name: db_gpio_tx
+    width: 16
+
 # AXI4 memory-mapped interface (up to 8 x 512-bit data and 48-bit address)
 axi4_mm:
   type: master-slave

--- a/host/include/uhd/rfnoc/core/x310_bsp.yml
+++ b/host/include/uhd/rfnoc/core/x310_bsp.yml
@@ -45,6 +45,19 @@ io_ports:
     rename:
       pattern: (.*)
       repl: \1_radio1
+  # Daughterboard GPIO
+  db0_gpio: # the srcport to be used in image_core.yml
+    type: db_gpio # the id from io_signatures.yml
+    drive: broadcaster
+    rename:
+      pattern: db_gpio_(.*) # the port names from io_signatures.yml (db_gpio_rx and db_gpio_tx)
+      repl: gpio_db0_\1 # the corresponding verilog signal in bus_int.v (gpio_db0_rx and gpio_db0_tx)
+  db1_gpio:
+    type: db_gpio
+    drive: broadcaster
+    rename:
+      pattern: db_gpio_(.*)
+      repl: gpio_db1_\1
   dram:
     type: axi4_mm
     drive: slave

--- a/host/include/uhd/rfnoc/core/x310_bsp.yml
+++ b/host/include/uhd/rfnoc/core/x310_bsp.yml
@@ -46,18 +46,30 @@ io_ports:
       pattern: (.*)
       repl: \1_radio1
   # Daughterboard GPIO
-  db0_gpio: # the srcport to be used in image_core.yml
+  gpio_db0_rx: # the srcport to be used in image_core.yml
     type: db_gpio # the id from io_signatures.yml
     drive: broadcaster
     rename:
-      pattern: db_gpio_(.*) # the port names from io_signatures.yml (db_gpio_rx and db_gpio_tx)
-      repl: gpio_db0_\1 # the corresponding verilog signal in bus_int.v (gpio_db0_rx and gpio_db0_tx)
-  db1_gpio:
+      pattern: gpio_(.*) # the port names from io_signatures.yml
+      repl: gpio_db0_rx_\1 # the corresponding verilog signal in bus_int.v
+  gpio_db0_tx:
     type: db_gpio
     drive: broadcaster
     rename:
-      pattern: db_gpio_(.*)
-      repl: gpio_db1_\1
+      pattern: gpio_(.*)
+      repl: gpio_db0_tx_\1
+  gpio_db1_rx:
+    type: db_gpio
+    drive: broadcaster
+    rename:
+      pattern: gpio_(.*)
+      repl: gpio_db1_rx_\1
+  gpio_db1_tx:
+    type: db_gpio
+    drive: broadcaster
+    rename:
+      pattern: gpio_(.*)
+      repl: gpio_db1_tx_\1
   dram:
     type: axi4_mm
     drive: slave


### PR DESCRIPTION
Adds an IO-ports interface to access daughterboard GPIOs from custom RFNoC blocks with UHD 4.6 for an USRP X310

_See [UHD-4.8-GPIO](https://github.com/eltos/uhd/compare/UHD-4.8...UHD-4.8-GPIO) for UHD 4.8 compatible changes._

# Usage

Build this modified version of UHD from source as usual:
```bash
cd ~
git clone git@github.com:eltos/uhd.git
cd uhd
git checkout UHD-4.6-GPIO
cd host
mkdir build
cd build
cmake ..
make
sudo make install
```


In your custom RFNoC block YML (e.g. in `rfnoc-my_oot_module/blocks/my_block.yml`) specify the interface by adding the following io_ports definition (for each GPIO bank you want to connect, see below):
```yml
io_ports:
  gpio: # the dstport to be used in image_core.yml
    type: db_gpio # the id from uhd io_signatures.yml
    drive: listener
  #second_gpio:
  #  type: db_gpio
  #  drive: listener
  #  rename:
  #    pattern: gpio_(.*)
  #    repl: second_gpio_\1
```
Note that as of UHD 4.6 the `rfnoc_create_verilog.py` tool does not take `io_ports` into account when generating the verilog files for you. Therefore, you have to add the wires manually to your block code (e.g. in `rfnoc-my_oot_module/fpga/rfnoc_block_my_block/rfnoc_block_my_block.v`):
```verilog

module rfnoc_block_my_block #(
  ...
)(
  ...
  // Daughterboard GPIO
  output wire [15:0] gpio_ctr,
  output wire [15:0] gpio_ddr,
  input  wire [15:0] gpio_in,
  output wire [15:0] gpio_out,
  //output wire [15:0] second_gpio_ctr,
  //output wire [15:0] second_gpio_ddr,
  //input  wire [15:0] second_gpio_in,
  //output wire [15:0] second_gpio_out,
  ...
);

  ...

  // GPIO handling
  assign gpio_ctr[1:0] = 2'b11; // take control over gpio pin [0] and [1]
  assign gpio_ddr[1:0] = 2'b10; // set data-direction (0=input for pin [0], 1=output for pin [1])
  assign gpio_out[1] = ... // TODO: drive this output
  ... = gpio_in[0]; // TODO use this input

endmodule
```
These wires are:
- `gpio_ctr`: a bitmask controlling which GPIOs are controlled by the RFNoC block. 1 means that a GPIO is controlled by the block via the following wires, while the UHD GPIO API (including ATR) is disabled for this pin. 0 (default) means the opposite.
- `gpio_ddr`: the data-direction bitmask: 0=input, 1=output (default)
- `gpio_in`: the input signal
- `gpio_out`: the output signal

Then, in the image core YML (e.g. in `rfnoc-my_oot_module/icores/x310_rfnoc_image_core.yml` connect the GPIOs to your block:
```yml
...
noc_blocks:
  myblock:
    block_desc: 'my_block.yml'
  ...
clk_domains:
  ...

connections:
  // connect GPIOs from RX bank on daughterboard on radio0
  - { srcblk: _device_, srcport: gpio_db0_rx, dstblk: myblock, dstport: gpio } 
  // connect GPIOs from TX bank on daughterboard on radio1
  //- { srcblk: _device_, srcport: gpio_db1_tx, dstblk: myblock, dstport: second_gpio } 
  ...

```


Then, you can use the image builder to generate the FPGA files:
```bash
cd rfnoc-my_oot_module/build
rfnoc_image_builder -F ~/uhd/fpga/ -I ../ -y ../icores/x310_rfnoc_image_core.yml --generate-only
```
Inspect the generated `x310_rfnoc_image_core.v` file (search for gpio) to see how the GPIOs banks of the specified radio daugherboard got connected to your RFNoC block. Then build the image as usual with:
```bash
cd rfnoc-my_oot_module/build
rfnoc_image_builder -F ~/uhd/fpga/ -I ../ -y ../icores/x310_rfnoc_image_core.yml
```



